### PR TITLE
refactor date format to DD-MM-YYYY in statistics block

### DIFF
--- a/src/components/Statistics.tsx
+++ b/src/components/Statistics.tsx
@@ -5,14 +5,18 @@ export type StatisticsType = {
 
 export default function Statistics(props: StatisticsType) {
   const { questionsCount, lastUpdated } = props;
+
+  // convert the date to format DD-MM-YYYY
+  const lastUpdatedDate = new Date(lastUpdated).toLocaleDateString();
+
   return (
-    <div className='card'>
-      <header className='card-header'>
-        <p className='card-header-title'>Statistics</p>
+    <div className="card">
+      <header className="card-header">
+        <p className="card-header-title">Statistics</p>
       </header>
-      <div className='card-content'>
-        <div className='content'>Questions in DB: {String(questionsCount)}</div>
-        <div className='content'>Last updated: {lastUpdated}</div>
+      <div className="card-content">
+        <div className="content">Questions in DB: {String(questionsCount)}</div>
+        <div className="content">Last updated: {lastUpdatedDate}</div>
         {/* <div className='content'>Registered users: {String(questionsCount)}</div> */}
       </div>
     </div>


### PR DESCRIPTION
Closes #19 

The statistics block looked like the following earlier:
![image](https://user-images.githubusercontent.com/70171925/195929733-a4294baf-f88c-4450-b89b-0893e854959a.png)

Now it looks like the following:
![image](https://user-images.githubusercontent.com/70171925/195929774-6905557a-f123-4ef7-bb98-cb5bb7a1cd85.png)
