### PR TITLE
fix: if not signed, show another block instead of comments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -229,14 +229,13 @@ export const App = () => {
             </div>
           )}
 
-          {isAuthenticated && (
-            <div className='block'>
-              <Comments
-                comments={question.comments}
-                onCommentSend={sendCommentHandler}
-              />
-            </div>
-          )}
+          <div className='block'>
+            <Comments
+              comments={question.comments}
+              onCommentSend={sendCommentHandler}
+              isAuthenticated={isAuthenticated}
+            />
+          </div>
         </div>
 
         <div className='column'>

--- a/src/components/Comments/CommentsBlock.tsx
+++ b/src/components/Comments/CommentsBlock.tsx
@@ -4,10 +4,11 @@ import Comment, { CommentType } from './Comment';
 type Props = {
   onCommentSend: (comment: string) => void;
   comments: CommentType[];
+  isAuthenticated: boolean;
 };
 
 export default function Comments(props: Props) {
-  const { comments } = props;
+  const { comments, isAuthenticated } = props;
 
   const [comment, setComment] = useState('');
 
@@ -27,33 +28,37 @@ export default function Comments(props: Props) {
         </header>
         <div className='card-content'>
           <div className='content'>
-            {commentsMap}
+            {isAuthenticated ? (
+            <>
+              {commentsMap}
 
-            <div className='field'>
-              <label className='label'>Message</label>
-              <div className='control'>
-                <textarea
-                  className='textarea'
-                  placeholder={comment}
-                  onChange={(e) => setComment(e.target.value)}
-                  value={comment}
-                ></textarea>
+              <div className='field'>
+                <label className='label'>Message</label>
+                <div className='control'>
+                  <textarea
+                    className='textarea'
+                    placeholder={comment}
+                    onChange={(e) => setComment(e.target.value)}
+                    value={comment}
+                  ></textarea>
+                </div>
               </div>
-            </div>
 
-            <div className='field is-grouped'>
-              <div className='control'>
-                <button
-                  className='button is-info'
-                  onClick={() => {
-                    setComment('');
-                    props.onCommentSend(comment);
-                  }}
-                >
-                  Submit
-                </button>
+              <div className='field is-grouped'>
+                <div className='control'>
+                  <button
+                    className='button is-info'
+                    onClick={() => {
+                      setComment('');
+                      props.onCommentSend(comment);
+                    }}
+                  >
+                    Submit
+                  </button>
+                </div>
               </div>
-            </div>
+            </>
+            ) : <p>Sign in to see comments</p>}
           </div>
         </div>
       </div>


### PR DESCRIPTION
For unauthenticated users, `Sign in to see comments` message is displayed in a block. 

Closes #26 

<img width="1199" alt="Screenshot 2022-10-18 at 1 09 18 PM" src="https://user-images.githubusercontent.com/41188167/196374744-cdcd1344-9b60-48b8-bc2c-55dd3ca0d52b.png">
